### PR TITLE
Capture award metadata during ingestion

### DIFF
--- a/docs/sql_guide.md
+++ b/docs/sql_guide.md
@@ -32,6 +32,16 @@ GROUP BY o.agency
 ORDER BY attachment_count DESC;
 ```
 
+## Recent Award Activity
+
+```sql
+SELECT o.notice_id, o.title, aw.award_type, aw.amount, aw.date
+FROM awards aw
+JOIN opportunities o ON o.id = aw.opportunity_id
+WHERE datetime(aw.date) >= datetime('now', '-90 days')
+ORDER BY datetime(aw.date) DESC;
+```
+
 ## Full-Text Search
 
 ```sql


### PR DESCRIPTION
## Summary
- persist award metadata returned from SAM.gov responses alongside each opportunity
- document a SQL helper query for reviewing recent award activity

## Testing
- python -m compileall samwatch/ingest.py

------
https://chatgpt.com/codex/tasks/task_e_68d7056a547c8323acfd60818e21c262