### PR TITLE
Add scheduler CLI command for continuous ingestion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ Build a Python service (`samwatch/`) that continuously scans SAM.gov opportuniti
 - *2024-05-05*: Initialized mission tracker file.
 - *2024-05-09*: Expanded tracker with full project plan, constraints, and phased roadmap.
 - *2024-05-10*: Implemented scaffolding, configuration, rate limiting, client, and database layers; added run tracking for ingestion sweeps.
+- *2024-05-11*: Added scheduler-driven CLI orchestration with periodic health checks.
 
 ## Working Agreements
 - Keep SAM API keys out of source control (load from environment `SAM_API_KEY`).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ rate limiting primitives, an HTTP client, and database schema definitions.
 - HTTP client helpers for searching opportunities, retrieving descriptions, and downloading
   attachments
 - SQLite schema with tables for opportunities, contacts, attachments, and alerting rules
-- Typer-based command line interface for running ingestion pipelines and queries
+- Typer-based command line interface for running ingestion pipelines, scheduling loops, and
+  querying persisted data
 - Run tracking persisted in the SQLite `runs` table with per-run metrics
 - Multi-channel alerting engine that can emit matches via CLI, webhooks, or email
 
@@ -34,6 +35,13 @@ rate limiting primitives, an HTTP client, and database schema definitions.
 
    ```bash
    samwatch run --hot
+   ```
+
+4. To operate continuously, launch the scheduler which orchestrates the hot, warm, and refresh
+   sweeps alongside health checks:
+
+   ```bash
+   samwatch serve
    ```
 
 ## Development

--- a/samwatch/AGENTS.md
+++ b/samwatch/AGENTS.md
@@ -61,10 +61,11 @@ Stand up the initial project scaffolding (package layout, config plumbing, rate 
 - [x] Documentation (SQL guide + ops) drafted and versioned.
 
 ## Next Action Steps
-1. Integrate scheduler automation and health checks for long-running services.
-2. Build notification templates and delivery retries for alerts.
-3. Document deployment workflows and environment automation.
+1. Build notification templates and delivery retries for alerts.
+2. Document deployment workflows and environment automation.
+3. Capture scheduler run metrics and expose health dashboards.
 
 ## Activity Log
 - *2024-05-09*: Created `samwatch/AGENTS.md` to drive build execution within the `samwatch/` package scope.
 - *2024-05-10*: Completed config, rate limiting, client, and database modules; added ingestion run tracking and outlined remaining alerting work.
+- *2024-05-11*: Wired scheduler-driven CLI command with health checks for continuous ingestion.


### PR DESCRIPTION
## Summary
- add a `samwatch serve` command that schedules hot, warm, and refresh loops with periodic health checks
- wire scheduler usage into the CLI with logging and configuration-aware intervals
- document continuous operation workflows and update build trackers with the latest progress notes

## Testing
- python -m compileall samwatch

------
https://chatgpt.com/codex/tasks/task_e_68d70c2694e483239d4056f13bbfc2cd