### PR TITLE
Adopt timezone-aware timestamps across ingestion and scheduler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Build a Python service (`samwatch/`) that continuously scans SAM.gov opportuniti
 - *2024-05-11*: Added scheduler-driven CLI orchestration with periodic health checks.
 - *2024-05-12*: Delivered alert templating with retries, scheduler metrics, and deployment documentation.
 - *2024-05-13*: Added integration coverage for ingestion hot sweeps and alert rule evaluation.
+- *2024-05-14*: Replaced naive UTC helpers with timezone-aware timestamps to silence deprecation warnings and standardize ISO serialization.
 
 ## Working Agreements
 - Keep SAM API keys out of source control (load from environment `SAM_API_KEY`).

--- a/samwatch/AGENTS.md
+++ b/samwatch/AGENTS.md
@@ -70,3 +70,4 @@ Stand up the initial project scaffolding (package layout, config plumbing, rate 
 - *2024-05-11*: Wired scheduler-driven CLI command with health checks for continuous ingestion.
 - *2024-05-12*: Added templated alert delivery with retries, scheduler metrics, and deployment documentation.
 - *2024-05-13*: Implemented end-to-end ingestion and alert integration tests to validate orchestration flows.
+- *2024-05-14*: Updated ingestion, refresher, and scheduler codepaths to use timezone-aware timestamps for compatibility with modern Python.

--- a/samwatch/backfill.py
+++ b/samwatch/backfill.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 from .config import Config
 
@@ -43,7 +43,7 @@ class BackfillPlanner:
     def next_window_from_db(self, last_recorded: datetime | None) -> BackfillWindow:
         """Return the next window to process based on persisted metadata."""
 
-        today = datetime.utcnow().date()
+        today = datetime.now(UTC).date()
         if last_recorded is None:
             start = today - timedelta(days=self.window_days)
         else:

--- a/samwatch/db.py
+++ b/samwatch/db.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 SCHEMA_STATEMENTS: Sequence[str] = (
@@ -160,7 +160,12 @@ class Database:
     def _timestamp() -> str:
         """Return a UTC timestamp in ISO 8601 format."""
 
-        return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+        return (
+            datetime.now(UTC)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
 
     def connect(self) -> sqlite3.Connection:
         if self._connection is None:

--- a/samwatch/ingest.py
+++ b/samwatch/ingest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -37,7 +37,7 @@ class IngestionOrchestrator:
     def run_hot(self) -> None:
         """Scan the current day for new or updated notices."""
 
-        today = datetime.utcnow().date()
+        today = datetime.now(UTC).date()
         params = {
             "postedFrom": today.isoformat(),
             "postedTo": today.isoformat(),
@@ -48,7 +48,7 @@ class IngestionOrchestrator:
     def run_warm(self, days: int = 7) -> None:
         """Rescan the last ``days`` for amendments or cancellations."""
 
-        end = datetime.utcnow().date()
+        end = datetime.now(UTC).date()
         start = end - timedelta(days=days)
         params = {
             "postedFrom": start.isoformat(),

--- a/samwatch/refresher.py
+++ b/samwatch/refresher.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from .client import SAMWatchClient
 from .config import Config
@@ -33,9 +33,10 @@ class Refresher:
         self._ingestor.upsert_record(record)
 
     def refresh_recent(self, hours: int = 24) -> None:
-        window_start = datetime.utcnow() - timedelta(hours=hours)
-        logger.info("Refreshing opportunities changed since %s", window_start.isoformat())
-        data = self.client.search_opportunities({"modifiedFrom": window_start.isoformat()})
+        window_start = datetime.now(UTC) - timedelta(hours=hours)
+        iso_start = window_start.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+        logger.info("Refreshing opportunities changed since %s", iso_start)
+        data = self.client.search_opportunities({"modifiedFrom": iso_start})
         for record in data.get("opportunitiesData", []):
             notice_id = record.get("noticeId")
             if notice_id:

--- a/samwatch/scheduler.py
+++ b/samwatch/scheduler.py
@@ -7,7 +7,7 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
@@ -83,7 +83,7 @@ class Scheduler:
                     logger.debug("Executing job %s", job.name)
                     metrics = self._metrics.setdefault(job.name, JobMetrics())
                     metrics.runs_started += 1
-                    metrics.last_started_at = datetime.utcnow()
+                    metrics.last_started_at = datetime.now(UTC)
                     start_time = time.monotonic()
                     if self._metrics_recorder is not None:
                         self._metrics_recorder.record_job_start(job)
@@ -103,7 +103,7 @@ class Scheduler:
                             duration = time.monotonic() - start_time
                             self._metrics_recorder.record_job_success(job, duration)
                     finally:
-                        metrics.last_finished_at = datetime.utcnow()
+                        metrics.last_finished_at = datetime.now(UTC)
                         next_run[job.name] = now + job.interval.total_seconds()
             time.sleep(1)
 


### PR DESCRIPTION
## Summary
- replace naive `datetime.utcnow()` usage with timezone-aware helpers across ingestion, backfill, scheduler, and refresher code paths
- standardize generated timestamps to ISO 8601 Z-format for database records and refresh queries
- document the progress update in the repository and package activity logs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9726df4ec8323918c40d932cf76d8